### PR TITLE
Only send back external id as response to creation

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -20,4 +20,10 @@ class Recipe < ApplicationRecord
     self.external_id = ExternalIdGenerator.new(id: id).call
     save!
   end
+
+  def as_json
+    {
+      external_id: external_id
+    }
+  end
 end

--- a/test/controllers/api/v1/recipes_controller_test.rb
+++ b/test/controllers/api/v1/recipes_controller_test.rb
@@ -19,6 +19,9 @@ class Api::V1::RecipesControllerTest < ActionDispatch::IntegrationTest
       post api_v1_recipes_url, params: params
     end
 
+    response_body = JSON.parse(@response.body).with_indifferent_access
+    assert_not_nil(response_body[:external_id])
+
     assert_response :success
   end
 


### PR DESCRIPTION
Clients can do a GET request using this reference id to fetch additional details