### PR TITLE
Fix action to run before filter

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::RecipesController < ApplicationController
 
   before_action :validate_recipe, only: [:create]
   before_action :validate_steps, only: [:create]
-  before_action :validate_external_id, only: [:delete]
+  before_action :validate_external_id, only: [:destroy]
 
   def index
     all_recipes = Recipe.active.all.map { |recipe| recipe.as_json }
@@ -45,13 +45,13 @@ class Api::V1::RecipesController < ApplicationController
   private
 
   def validate_external_id
-    recipe = Recipe.find_by(external_id: params[:id])
+    recipe = Recipe.active.find_by(external_id: params[:id])
     return if recipe.present?
 
     not_found_error = ApiError.new(
       pointer: "/external_id",
       title: "Resource not found",
-      detail: "Recipe does not exist",
+      detail: "There is no active recipe by this id",
     )
     render_errors(status: 404, errors: [not_found_error])
   end

--- a/test/controllers/api/v1/recipes_controller_test.rb
+++ b/test/controllers/api/v1/recipes_controller_test.rb
@@ -91,10 +91,27 @@ class Api::V1::RecipesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "deleting a recipe sets it to inactive" do
-    recipe = Recipe.first
+    recipe = Recipe.where(is_active: true).first
 
     delete "/api/v1/recipes/#{recipe.external_id}"
     assert_equal(recipe.reload.is_active, false)
+  end
+
+  test "deleting a recipe with an invalid id results in an error" do
+    delete "/api/v1/recipes/idonotexist"
+    assert_response 404
+
+    error_response = {
+      errors: [
+        {
+          source: { pointer: "/external_id" },
+          title: "Resource not found",
+          detail: "There is no active recipe by this id",
+        },
+      ]
+    }.to_json
+
+    assert_equal(@response.body, error_response)
   end
 end
 

--- a/test/fixtures/recipes.yml
+++ b/test/fixtures/recipes.yml
@@ -4,8 +4,10 @@ one:
   name: "Alu Paratha"
   cuisine: "Indian"
   external_id: "abcdef"
+  is_active: true
 
 two:
   name: "Chicken Tikka"
   cuisine: "Indian"
   external_id: "pqrst"
+  is_active: false


### PR DESCRIPTION
* Attempting to delete a recipe that did not exist was resulting in a
500 because the before action was hooked to the wrong or rather non
existent endpoint
* Fixed it and also made sure we only attempt to delete active recipes