### PR TITLE
Using Webpack plugin

### DIFF
--- a/app/javascript/grid.jsx
+++ b/app/javascript/grid.jsx
@@ -1,6 +1,3 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-
 class Grid extends React.Component {
   render() {
     return (
@@ -11,4 +8,4 @@ class Grid extends React.Component {
   }
 }
 
-export { Grid }
+export default Grid;

--- a/app/javascript/packs/main.jsx
+++ b/app/javascript/packs/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
-import { Grid } from './grid'
+import Grid from '../grid'
 
 document.addEventListener('DOMContentLoaded', () => {
   ReactDOM.render(

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
+const webpack = require('webpack');
+
+environment.plugins.prepend(
+  'Provide',
+  new webpack.ProvidePlugin({
+    React: 'react'
+  })
+)
 
 module.exports = environment


### PR DESCRIPTION
* Instead of manually importing React in every file, using
[ProvidePlugin](https://webpack.js.org/plugins/provide-plugin) to
automatically load React (and other modules in the future(
* Using default export so that importing semantics is similar to
importing public react modules
* javascipt/packs is only supposed to be for the entry point files
that's linked in Rails views so moving the grid component out of it.